### PR TITLE
Update qbit_automatch.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Python 2.7+ or 3.2+ (according to [vermin](https://github.com/netromdk/vermin))
 [rapidfuzz](https://github.com/maxbachmann/RapidFuzz)
 
 ```
-python -m pip install bencode.py psutil rapidfuzz
+python -m pip install bencode.py psutil rapidfuzz==2.15.1
 ```
 or
 ```
-python3 -m pip install bencode.py psutil rapidfuzz
+python3 -m pip install bencode.py psutil rapidfuzz==2.15.1
 ```
 or
 ```
@@ -48,17 +48,22 @@ optional arguments:
                         3: use fuzzy string matching and choose files automatically but be prompted before proceeding
                         Defaults to 0
   -d, --debug           Enable debug
+
+  -r, --remap           Searches for all torrents tagged "fixme" in qbittorrent and edits these. Avoids the need to have to copy infohash.
 ```
 
 Windows:
 ```
 py qbit_automatch.py --hash HASH --search_dir SEARCH_DIR
+
+example with -r
+py qbit_automatch.py -r True --search_dir SEARCH_DIR
 ```
 Linux/OS X:
 ```
 python3 qbit_automatch.py --hash HASH --search_dir SEARCH_DIR
 ```
-* hash: Torrent hash. Can be obtained in qBittorrent UI by: Right Click Torrent -> Copy -> Hash  
+* hash: Torrent hash. Can be obtained in qBittorrent UI by: Right Click Torrent -> Copy -> Hash #Note you can right click and assign tag fixme, then use -r True to avoid needing individual hashes if doing many updates
 * search_dir: the absolute path of the root folder of the files which are already on the disk  
 * bt_backup: If your qBittorrent/BT_backup is not in the default location then you can use this parameter and input the correct absolute path  
 * fix_duplicates: If the script is matching torrent files with more than one disk file you can use this option to fix it manually or use string matching to decide the correct file  

--- a/qbit_automatch.py
+++ b/qbit_automatch.py
@@ -4,6 +4,7 @@ import collections
 import sys
 from shutil import copyfile
 from pathlib import Path
+import re
 
 try:
     import bencode
@@ -19,7 +20,7 @@ try:
     from rapidfuzz import process
     from rapidfuzz.string_metric import levenshtein
 except ModuleNotFoundError:
-    raise SystemExit('Error: The rapidfuzz module is needed, you can install it with this command: python -m pip install rapidfuzz')
+    raise SystemExit('Error: The rapidfuzz module is needed, you can install it with this command: python -m pip install rapidfuzz==2.15.1')
 
 def get_bt_backup_default():
     if sys.platform == "win32":
@@ -65,23 +66,44 @@ def find_file(search_dir_cache, file_length, file_extension, filename):
         if (file_length == i['length'] and
             file_extension == i['extension']):
             files.append(i['absolute_path'])
+            
     return files
 
-def update_fastresume(qBt_savePath, mapped_files):
+def check_tag(fastresume_path):
+    with open(os.path.join(bt_backup, fastresume_path), 'rb') as fd:
+        fastresume_data = bencode.decode(fd.read())
+    
+    if "fixme" in str(fastresume_data['qBt-tags']):
+        return True
+    else:
+        return False
+
+
+def update_fastresume(qBt_savePath, mapped_files,fastresume_path,fastresume_bkp_path):
     #Fetch the fastresume file data
+    
     with open(fastresume_path, 'rb') as fd:
         fastresume_data = bencode.decode(fd.read())
+    
     #update the root save path and files
     fastresume_data_upd=fastresume_data.copy()
+    #print(str(fastresume_data_upd))
     fastresume_data_upd['qBt-savePath']=qBt_savePath
     fastresume_data_upd['save_path']=qBt_savePath
     fastresume_data_upd['mapped_files']=mapped_files
     fastresume_data_upd['paused']=1
+    print("Updated bencode data with below file locations")
+
+    print(str(mapped_files))
     if fastresume_data == fastresume_data_upd:
         print('Info: Fastresume data matches already, no changes made')
         exit(0)
     if check_process_running('qbittorrent'):
-        raise SystemExit('Error: qBittorrent is running, close it first')
+        print("qbit runnign might cause issues..")
+        x=input("continue?[y/n]")
+        if x!="n":
+            pass
+        else: raise SystemExit('Error: qBittorrent is running, close it first')
     #backup the original fastresume file if bkp doesnt exists
     if not os.path.isfile(fastresume_bkp_path):
         copyfile(fastresume_path, fastresume_bkp_path)
@@ -89,13 +111,24 @@ def update_fastresume(qBt_savePath, mapped_files):
     with open(fastresume_path, 'wb') as fd:
         fd.write(bencode.encode(fastresume_data_upd))
 
-def rename_files(searched_files):
-    for file in input:
+def rename_files(searched_files,result):
+    
+    for file in searched_files:
+
         file_to_change = file["result"][0]
         file_to_change_name = file_to_change.split("\\")[-1:][0]
         file_location = file_to_change.replace(file_to_change_name,"")
         file_new_name = file_location + file["searched"]
-        os.rename(f"{file_to_change}",f"{file_new_name}")
+        try:
+            os.rename(f"{file_to_change}",f"{file_new_name}")
+        except:
+            print(f"ERROR ON RENAMING FILE {file_to_change}")
+        """if is_folder_name:
+            absolute_path = result[0]["absolute_path"]
+            folder_path = absolute_path.split("/")[:-1]
+            print(str(folder_path))
+            folder_path = "/".join(folder_path)
+            print(str(folder_path))"""
     #todo1 - update the fast resume data after files are renamed so that file doesnt need to be rechecked.
     #todo2 - rename parent folder also where required.
     
@@ -103,11 +136,12 @@ parser=argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 optional = parser._action_groups.pop()
 required = parser.add_argument_group('required arguments')
 parser._action_groups.append(optional)
-required.add_argument('-a', '--hash', help='Torrent hash. In qBittorrent right click the torrent -> copy -> hash', required=True)
+required.add_argument('-a', '--hash', help='Torrent hash. In qBittorrent right click the torrent -> copy -> hash', required=False)
 required.add_argument('-s', '--search_dir', metavar='PATH', help='Where to search for the files. Must be an absolute path', required=True)
 optional.add_argument('-b', '--bt_backup', metavar='PATH', default=get_bt_backup_default(), help='BT_backup location, defaults to:\nWindows: C:\\Users\\<username>\\AppData\\Local\\qBittorrent\\BT_backup\nLinux: /home/<username>/.local/share/data/qBittorrent/BT_backup\nOS X: /Users/<username/Library/ApplicationSupport/qBittorrent/BT_backup')
 optional.add_argument('-f', '--fix_duplicates', metavar='N', default=0, help='Values:\n0: throw an error when duplicates are found\n1: be prompted to choose files when duplicates are found\n2: use fuzzy string matching and choose files automatically\n3: use fuzzy string matching and choose files automatically but be prompted before proceeding\nDefaults to 0')
 optional.add_argument('-d', '--debug', action='store_true', help='Enable debug')
+optional.add_argument('-r', '--remap', help='Enable repair', default=False)
 args=parser.parse_args()
 
 #Validate input
@@ -117,104 +151,137 @@ if not os.path.isdir(args.search_dir):
 if not os.path.isdir(args.bt_backup):
     raise SystemExit('Error: ' + args.bt_backup + ' is not a valid dir. Try calling the script with --bt_backup parameter and the correct path')
 
+remap = args.remap
+torrent_paths = []
 bt_backup=args.bt_backup
-torrent_path=os.path.join(bt_backup, args.hash + '.torrent')
-fastresume_path=os.path.join(bt_backup, args.hash + '.fastresume')
-fastresume_bkp_path=fastresume_path + '.bkp'
-
-if args.debug: print('hash..........: ' + args.hash)
-if args.debug: print('search_dir....: ' + args.search_dir)
-if args.debug: print('BT_backup.....: ' + bt_backup)
-if args.debug: print('torrent.......: ' + torrent_path)
-if args.debug: print('fastresume....: ' + fastresume_path)
-if args.debug: print('fastresume_bkp: ' + fastresume_bkp_path)
-
-#Cache the search_dir
-search_dir_cache=cache_search_dir(args.search_dir)
-
-#Parse torrent file and search the lenghts and extension in the search_dir
-searched_files=[]
-with open(torrent_path, 'rb') as fd:
-    torrent_data = bencode.decode(fd.read())
-    for td_file in torrent_data['info']['files']:
-        td_filename, td_file_extension = os.path.splitext(td_file['path'][-1])
-        td_file_length=int(td_file['length'])
-        result=find_file(search_dir_cache, td_file_length, td_file_extension, td_file['path'][-1])
-        searched_files.append({'searched':os.sep.join(td_file['path']), 'result':result})
-
-#Check if some files haven't been found
-not_found_abort=False
-for i in searched_files:
-    if not i['result']:
-        print('File not found: ' + i['searched'])
-        not_found_abort=True
-if not_found_abort:
-    raise SystemExit('Error: This is script only works if all files are accounted for within the search_dir')
-
-#Check if a file has duplicates
-duplicate_abort=False
-for i in searched_files:
-    if len(i['result']) > 1:
-        if args.fix_duplicates == '1':
-            print('File "' + i['searched'] + '" has the following duplicates. Input which is the correct one by entering the number:')
-        else:
-            print('File "' + i['searched'] + '" has the following duplicates:')
-        for idx, val in enumerate(i['result']):
-            print(' [' + str(idx) + '] ' + val)
-            duplicate_abort=True
-        if args.fix_duplicates in ['2','3']:
-            cache_result=process.extractOne(i['searched'], i['result'], scorer=levenshtein)[0]
-            i['result'] = []
-            i['result'].append(cache_result)
-            print('Fuzzy match: ' + cache_result)
-        elif args.fix_duplicates == '1':
-            while True:
-                try:
-                    user_input=int(input("Enter your value: "))
-                    cache_result=i['result'][user_input]
-                    i['result'] = []
-                    i['result'].append(cache_result)
-                    break
-                except (IndexError,TypeError,ValueError) as e:
-                    pass
-if duplicate_abort and args.fix_duplicates not in ['1','2','3']:
-    raise SystemExit('Error: duplicates found. This happens when 2 files have the same length and extension. You can run the script with --fix_duplicates to fix them. Check the help for possible values')
-if duplicate_abort and args.fix_duplicates in ['3']:
-    if not yes_or_no('Continue?'):
-        exit(0)
-
-#extract the paths
-searched_paths=[]
-for i in searched_files:
-    searched_paths.append(i['result'][0])
-
-if len(searched_paths) != len(set(searched_paths)):
-    raise SystemExit('Error: There are duplicates in the values')
-
-print('All files matched')
-
-#Get the common path of all files and set the mapped_files as the relative path to the common path
-mapped_files=[]
-qBt_savePath=str(Path(os.path.commonpath(searched_paths)).parent)
-for file_path in searched_paths:
-    relpath=os.path.relpath(file_path, qBt_savePath)
-    mapped_files.append(relpath)
-
-if args.debug: print('qBt_savePath..: ' + qBt_savePath)
-
-files_or_fastresume = input("(1) Rename Files\n(2) Update fast resume data\n\nSelection:")
-
-#if rename files option is selected rename files
-if files_or_fastresume == "1":
-    rename_files(searched_files)
-    print("all files renamed")
-    
-#If update fast resume is selected, Updates qBittorrent fastresume file
-elif files_or_fastresume == "2":
-    update_fastresume(qBt_savePath, mapped_files)
-    print('Updated fastresume file')
+if remap:
+    all_torrentfiles = os.listdir(bt_backup)
+    for torrentfile in all_torrentfiles:
+        if ".torrent" in torrentfile:
+            torrent_path = torrentfile.replace(".torrent","")
+            if check_tag(os.path.join(torrent_path + '.fastresume')):
+                torrent_paths.append(os.path.join(bt_backup,torrent_path))
+                #print(f"fixing {torrent_path}")
 
 else:
-    print("incorrect selection")    
+    torrent_paths.append(os.path.join(bt_backup, args.hash ))
 
-    print('Done')
+
+def run_check(torrent_path2,files_or_fastresume):
+    torrent_path=torrent_path2 + '.torrent'
+
+    fastresume_path=os.path.join(torrent_path2 + '.fastresume')
+    fastresume_bkp_path=fastresume_path + '.bkp'
+
+    if args.debug: print('hash..........: ' + args.hash)
+    if args.debug: print('search_dir....: ' + args.search_dir)
+    if args.debug: print('BT_backup.....: ' + bt_backup)
+    if args.debug: print('torrent.......: ' + torrent_path)
+    if args.debug: print('fastresume....: ' + fastresume_path)
+    if args.debug: print('fastresume_bkp: ' + fastresume_bkp_path)
+
+    #Cache the search_dir
+    search_dir_cache=cache_search_dir(args.search_dir)
+
+    #Parse torrent file and search the lenghts and extension in the search_dir
+    searched_files=[]
+    with open(torrent_path, 'rb') as fd:
+        torrent_data = bencode.decode(fd.read())
+        
+
+        for td_file in torrent_data['info']['files']:
+            td_filename, td_file_extension = os.path.splitext(td_file['path'][-1])
+            td_file_length=int(td_file['length'])
+
+            result=find_file(search_dir_cache, td_file_length, td_file_extension, td_file['path'][-1])
+            searched_files.append({'searched':os.sep.join(td_file['path']), 'result':result})
+
+    #Check if some files haven't been found
+    not_found_abort=False
+    for i in searched_files:
+        if not i['result']:
+            print('File not found: ' + i['searched'])
+            not_found_abort=True
+    if not_found_abort:
+        continuerunning = "n"
+        #continuerunning=input("do you want to continue[y/n]:")
+        if not continuerunning == "y":
+            raise SystemExit('Error: This is script only works if all files are accounted for within the search_dir')
+
+    #Check if a file has duplicates
+    duplicate_abort=False
+    for i in searched_files:
+        if len(i['result']) > 1:
+            if args.fix_duplicates == '1':
+                print('File "' + i['searched'] + '" has the following duplicates. Input which is the correct one by entering the number:')
+            else:
+                print('File "' + i['searched'] + '" has the following duplicates:')
+            for idx, val in enumerate(i['result']):
+                print(' [' + str(idx) + '] ' + val)
+                duplicate_abort=True
+            if args.fix_duplicates in ['2','3']:
+                cache_result=process.extractOne(i['searched'], i['result'], scorer=levenshtein)[0]
+                i['result'] = []
+                i['result'].append(cache_result)
+                print('Fuzzy match: ' + cache_result)
+            elif args.fix_duplicates == '1':
+                while True:
+                    user_input=int(input("Enter your value: "))
+                    try:
+                        cache_result=i['result'][user_input]
+                        i['result'] = []
+                        i['result'].append(cache_result)
+                        break
+                    except (IndexError,TypeError,ValueError) as e:
+                        pass
+    if duplicate_abort and args.fix_duplicates not in ['1','2','3']:
+        raise SystemExit('Error: duplicates found. This happens when 2 files have the same length and extension. You can run the script with --fix_duplicates to fix them. Check the help for possible values')
+    if duplicate_abort and args.fix_duplicates in ['3']:
+        if not yes_or_no('Continue?'):
+            exit(0)
+
+    #extract the paths
+    searched_paths=[]
+    for i in searched_files:
+        searched_paths.append(i['result'][0])
+
+    if len(searched_paths) != len(set(searched_paths)):
+        raise SystemExit('Error: There are duplicates in the values')
+
+    print('All files matched')
+
+    #Get the common path of all files and set the mapped_files as the relative path to the common path
+    mapped_files=[]
+    qBt_savePath=str(Path(os.path.commonpath(searched_paths)).parent)
+    
+    for file_path in searched_paths:
+        relpath=os.path.relpath(file_path, qBt_savePath)
+        mapped_files.append(relpath)
+    print(str(mapped_files[0]))
+    if args.debug: print('qBt_savePath..: ' + qBt_savePath)
+
+    
+
+    #if rename files option is selected rename files
+    if files_or_fastresume == "1":
+        rename_files(searched_files,result)
+        print("all files renamed")
+        
+    #If update fast resume is selected, Updates qBittorrent fastresume file
+    elif files_or_fastresume == "2":
+        update_fastresume(qBt_savePath, mapped_files,fastresume_path, fastresume_bkp_path)
+        print('Updated fastresume file')
+
+    else:
+        print("incorrect selection")    
+
+        print('Done')
+
+files_or_fastresume = input("(1) Rename Files\n(2) Update fast resume data\n\nSelection:")
+#files_or_fastresume = "2"
+warning = input("WARNING CLOSE QBIT FULLY PRIOR TO RUNNING TO AVOID ISSUES. PRESS ANY KEY TO CONTINUE.")
+for torrent_path in torrent_paths:
+    try:
+        run_check(torrent_path,files_or_fastresume)
+    except:
+        print(f"error on {torrent_path}")

--- a/qbit_automatch.py
+++ b/qbit_automatch.py
@@ -89,6 +89,16 @@ def update_fastresume(qBt_savePath, mapped_files):
     with open(fastresume_path, 'wb') as fd:
         fd.write(bencode.encode(fastresume_data_upd))
 
+def rename_files(searched_files):
+    for file in input:
+        file_to_change = file["result"][0]
+        file_to_change_name = file_to_change.split("\\")[-1:][0]
+        file_location = file_to_change.replace(file_to_change_name,"")
+        file_new_name = file_location + file["searched"]
+        os.rename(f"{file_to_change}",f"{file_new_name}")
+    #todo1 - update the fast resume data after files are renamed so that file doesnt need to be rechecked.
+    #todo2 - rename parent folder also where required.
+    
 parser=argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 optional = parser._action_groups.pop()
 required = parser.add_argument_group('required arguments')
@@ -192,8 +202,19 @@ for file_path in searched_paths:
 
 if args.debug: print('qBt_savePath..: ' + qBt_savePath)
 
-#Updates qBittorrent fastresume file
-update_fastresume(qBt_savePath, mapped_files)
+files_or_fastresume = input("(1) Rename Files\n(2) Update fast resume data\n\nSelection:")
 
-print('Updated fastresume file')
-print('Done')
+#if rename files option is selected rename files
+if files_or_fastresume == "1":
+    rename_files(searched_files)
+    print("all files renamed")
+    
+#If update fast resume is selected, Updates qBittorrent fastresume file
+elif files_or_fastresume == "2":
+    update_fastresume(qBt_savePath, mapped_files)
+    print('Updated fastresume file')
+
+else:
+    print("incorrect selection")    
+
+    print('Done')


### PR DESCRIPTION
Added selection option to 1) rename files or 2) update fast resume data
New function to rename files if 1 selected.

#notes:
Doesnt update fast resume data, so torrent still needs to be manually checked.
Doesnt update the parent folder name if there are files in a folder for the torrent.

background:
For many reasons it can be needed to rename files back to original torrent file naming convention instead. 
On PT you need different torrents per tracker so can have multiple torrents for the same files. instead of running this for each torrent, its better to retain the naming convention of the files correctly once. 